### PR TITLE
Add ansible-lint workflow

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,13 @@
+exclude_paths:
+  - .cache/
+  - .github/
+
+skip_list:
+  - var-naming
+
+enable_list:
+  - yaml  # log a runtime failure if yammllint is not installed
+
+kinds:
+  - tasks: "**/tasks/*.yml"
+  - meta: "**/meta/main.yml"

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -1,0 +1,21 @@
+name: Linters
+
+on:
+  pull_request:
+
+  push:
+    branches:
+      - master
+      - release_*
+
+jobs:
+  ansible-lint:
+    name: ansible-lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+
+      - name: Run ansible-lint
+        uses: containerbuildsystem/actions/ansible-lint@master

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.pyc
-
 /tests/test.retry
 /tests/tmp
+.cache

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,12 +1,14 @@
 # Standards: 1.8
 galaxy_info:
+  role_name: osbs_namespace
+  namespace: containerbuildsystem
   author: Luiz Carvalho
   description: Setup OpenShift namespace for OSBS usage
   company: Red Hat, Inc.
   license: BSD
   min_ansible_version: 2.1
   platforms:
-    name: EL
-    versions:
-    - 7
+    - name: EL
+      versions:
+        - 7
 dependencies: []

--- a/tasks/configure_namespace.yml
+++ b/tasks/configure_namespace.yml
@@ -11,7 +11,7 @@
   with_items:
     - "{{ osbs_list_sa }}"
   tags:
-  - deployment-sa
+    - deployment-sa
 
 
 - name: Create rolebindings for service accounts
@@ -34,7 +34,7 @@
   with_items:
     - "{{ osbs_list_of_dict_sa_with_roles }}"
   tags:
-  - deployment-sa
+    - deployment-sa
 
 
 - name: "Create secrets"
@@ -53,7 +53,7 @@
   with_items:
     - "{{ osbs_list_of_dict_secrets }}"
   tags:
-  - osbs-secrets
+    - osbs-secrets
 
 
 # TODO: Cluster role: Admin does not have permissions to create/adjust limitranges!
@@ -62,7 +62,7 @@
     state: present
     definition: "{{ lookup('template', 'templates/limit_range.yml') | from_yaml }}"
   tags:
-  - limit-range
+    - limit-range
 
 
 - name: Create configmaps
@@ -79,29 +79,29 @@
         namespace: "{{ osbs_ocp_namespace }}"
   with_items: "{{ osbs_reactor_config_maps }}"
   tags:
-  - configmaps
+    - configmaps
 
 
 - name: Deploy pipeline tasks
   k8s:
     state: present
-    apply: yes
+    apply: true
     namespace: "{{ osbs_ocp_namespace }}"
     definition: "{{ lookup('url', '{{ item }}', split_lines=False) | from_yaml_all | list }}"
   with_items: "{{ osbs_tasks_definitions }}"
   tags:
-  - tasks
+    - tasks
 
 
 - name: Deploy pipelines
   k8s:
     state: present
-    apply: yes
+    apply: true
     namespace: "{{ osbs_ocp_namespace }}"
     definition: "{{ lookup('url', '{{ item }}', split_lines=False) | from_yaml_all | list }}"
   with_items: "{{ osbs_pipelines_definitions }}"
   tags:
-  - pipelines
+    - pipelines
 
 
 - name: Create PipelineRun cleaning CronJob
@@ -134,7 +134,7 @@
                         memory: 256Mi
                 restartPolicy: OnFailure
   tags:
-  - pipeline-pruner
+    - pipeline-pruner
 
 
 - name: Create Pod cleaning CronJob
@@ -170,6 +170,6 @@
                         memory: 256Mi
                 restartPolicy: OnFailure
   with_items:
-    - { name: "pod-pruner", template: "{{ lookup('template', 'templates/pod_pruner.sh') }}"}
+    - {name: "pod-pruner", template: "{{ lookup('template', 'templates/pod_pruner.sh') }}"}
   tags:
-  - cronjobs
+    - cronjobs

--- a/templates/limit_range.yml
+++ b/templates/limit_range.yml
@@ -7,10 +7,10 @@ metadata:
     tenant.paas.redhat.com/tenant: "{{ container_build_tenant }}"
 spec:
   limits:
-#    - type: openshift.io/ImageStream
-#      max:
-#        openshift.io/image-tags: 1k
-#        openshift.io/images: 1k
+    # - type: openshift.io/ImageStream
+    #   max:
+    #     openshift.io/image-tags: 1k
+    #     openshift.io/images: 1k
     - type: Pod
       max:
         cpu: "{{ osbs_cpu_max }}"
@@ -25,14 +25,14 @@ spec:
       min:
         cpu: 5m
         memory: 4Mi
-#      default:
-#        cpu: 500m
-#        memory: 512Mi
-#      defaultRequest:
-#        cpu: 25m
-#        memory: 256Mi
-#      maxLimitRequestRatio:
-#        cpu: '100'
+        # default:
+        #   cpu: 500m
+        #   memory: 512Mi
+        # defaultRequest:
+        #   cpu: 25m
+        #   memory: 256Mi
+        # maxLimitRequestRatio:
+        #   cpu: '100'
     - type: openshift.io/Image
       max:
         storage: "{{ osbs_max_storage }}"


### PR DESCRIPTION
I'm concerned about the 'role_name' & 'namespace' fields in 'meta/main.yml' - I don't know what's *supposed* to go there; I simply guessed.

Tested in ben-alkov/ansible-role-osbs-namespace PR 1 [linter run](https://github.com/ben-alkov/ansible-role-osbs-namespace/runs/4070539455?check_suite_focus=true)

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

- CLOUDBLD-7849