### PR TITLE
Forbid concurrent runs of pod pruner

### DIFF
--- a/tasks/configure_namespace.yml
+++ b/tasks/configure_namespace.yml
@@ -145,6 +145,7 @@
         name: "{{ item.name }}"
       spec:
         schedule: "{{ pod_pruning_schedule }}"
+        concurrencyPolicy: Forbid
         successfulJobsHistoryLimit: "{{ osbs_generic_cronjob_successful_jobs }}"
         failedJobsHistoryLimit: "{{ osbs_generic_cronjob_failed_jobs }}"
         jobTemplate:


### PR DESCRIPTION
This is a solution to a problem when a pod is stuck. Pod pruner is not able to remove it and won't finish. After some time, there will be multiple pod pruners running, all unable to finish. This will result in using up all the cronjobs resources